### PR TITLE
Change DoomEdNums to avoid Map conflicts

### DIFF
--- a/MAPINFO
+++ b/MAPINFO
@@ -3,15 +3,15 @@ GameInfo {
 }
 
 DoomEdNums{
-	23420=UZBHGen
-	23421=UZClaymoreMine
-	23422=UZClaymoreMineBox
-	23423=UZPlacedClaymore
-	23424=UZLandMine
-	23425=UZLandMinePickup
-	23426=UZLandMineBoxPickup
-	23427=UZLaserTripBombP
-	23428=UZLaserTripBombPickup
-	23429=UZPipeBombP
-    26430=UZPipeBombPickup
+	23460=UZBHGen
+	23461=UZClaymoreMine
+	23462=UZClaymoreMineBox
+	23463=UZPlacedClaymore
+	23464=UZLandMine
+	23465=UZLandMinePickup
+	23466=UZLandMineBoxPickup
+	23467=UZLaserTripBombP
+	23468=UZLaserTripBombPickup
+	23469=UZPipeBombP
+    26470=UZPipeBombPickup
 }


### PR DESCRIPTION
These DoomEdNums are just outside of the range that the Viridian Ranges use (23402 - 23457).
I could make that range smaller, as there are  quite a few blank, unused entries, but i'd like to keep them as placeholders for more custom decoration and items for my other maps.